### PR TITLE
Fix stale lockfile issue

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,3 +1,8 @@
+Version 0.12.3
+==============
+
+ * Fix bug in handling of stale lockfiles
+
 Version 0.9.1
 =============
 


### PR DESCRIPTION
Now we make sure there is an actual process running with
the pid stored in the lockfile before assuming we're already running.